### PR TITLE
bug fix: added symbol var to query

### DIFF
--- a/src/Api/Price.php
+++ b/src/Api/Price.php
@@ -45,7 +45,7 @@ class Price extends Api
     public function quotes(array $symbols)
     {
         return $this->client->getWithAuth('/marketdata/quotes', [
-            'query' => implode(',', $symbols)
+            'query' => ['symbol'=>implode(',', $symbols)]
         ]);
     }
 }


### PR DESCRIPTION
As per the docs "symbol= implode(',', $symbols)" was required request string.